### PR TITLE
Add Github issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,33 @@
+### Summary
+
+> Brief description of the issue. Please list any specific steps.
+> 
+> Example:
+> 1. Go to http://www.google.com
+> 2. Shift-Tab back to the About link
+
+### Expected result
+
+> What did you expect to happen?
+
+### Actual result
+
+> What actually did happen?
+
+### Example
+
+> A test case that demonstrates the issue - provide linked test case, CodePen, JSbin, etc...
+
+### Additional Information
+
+#### JAWS version and build number
+
+> Example: JAWS 18.0.4104
+ 
+#### Operating System and version
+
+> Example: Windows 10 Home 64-bit
+
+#### Browser and version:
+
+> Example: Firefox 56.0


### PR DESCRIPTION
Fixes #11 by adding an issue template that provides a default structure to new issues
based on the template in the README.